### PR TITLE
Generate and print seed phrase in `genaddr`

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -12,46 +12,17 @@
  * limitations under the License.
  */
 use crate::config::Config;
-use crate::crypto::{generate_keypair_from_mnemonic, KeyPair};
-use crate::helpers::read_keys;
+use crate::crypto::load_keypair;
 use chrono::{TimeZone, Local};
 use hex;
 use std::time::SystemTime;
 use ton_client_rs::{
-    TonClient, TonClientConfig, TonAddress, Ed25519KeyPair, EncodedMessage
+    TonClient, TonClientConfig, TonAddress, EncodedMessage
 };
 use ton_types::cells_serialization::{BagOfCells};
 
 fn now() -> u32 {
     SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as u32
-}
-
-fn keypair_to_ed25519pair(pair: KeyPair) -> Result<Ed25519KeyPair, String> {
-    let mut buffer = [0u8; 64];
-    let public_vec = hex::decode(&pair.public)
-        .map_err(|e| format!("failed to decode public key: {}", e))?;
-    let private_vec = hex::decode(&pair.secret)
-        .map_err(|e| format!("failed to decode private key: {}", e))?;
-
-    buffer[..32].copy_from_slice(&private_vec);
-    buffer[32..].copy_from_slice(&public_vec);
-
-    Ok(Ed25519KeyPair::zero().from_bytes(buffer))
-}
-
-fn load_keypair(keys: Option<String>) -> Result<Option<Ed25519KeyPair>, String> {
-    match keys {
-        Some(keys) => {
-            if keys.find(' ').is_none() {
-                let keys = read_keys(&keys)?;
-                Ok(Some(keys))
-            } else {
-                let pair = generate_keypair_from_mnemonic(&keys)?;
-                Ok(Some(keypair_to_ed25519pair(pair)?))
-            }
-        },
-        None => Ok(None),
-    }
 }
 
 fn create_client(url: String) -> Result<TonClient, String> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,9 +2,11 @@ use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use std::process::Command;
 
+const BIN_NAME: &str = "tonos-cli";
+
 #[test]
 fn test_config_url() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("tonlabs-cli")?;
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
     cmd.arg("config")
         .arg("--url")
         .arg("http://0.0.0.0");
@@ -18,7 +20,7 @@ fn test_config_url() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_call_giver() -> Result<(), Box<dyn std::error::Error>> {
     let giver_abi_name = "tests/samples/giver.abi.json";
-    let mut cmd = Command::cargo_bin("tonlabs-cli")?;
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
     cmd.arg("call")
         .arg("--abi")
         .arg(giver_abi_name)
@@ -33,13 +35,28 @@ fn test_call_giver() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn test_genaddr() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("tonlabs-cli")?;
+fn test_genaddr_genkey() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
     cmd.arg("genaddr")
         .arg("tests/samples/wallet.tvc")
         .arg("tests/samples/wallet.abi.json")
         .arg("--genkey")
-        .arg("tests/samples/wallet.keys.json")
+        .arg("tests/samples/wallet.keys.json");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Raw address"))
+        .stdout(predicate::str::contains("Seed phrase"))
+        .stdout(predicate::str::contains("Succeded"));
+
+    Ok(())
+}
+
+#[test]
+fn test_genaddr() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
+    cmd.arg("genaddr")
+        .arg("tests/samples/wallet.tvc")
+        .arg("tests/samples/wallet.abi.json")
         .arg("--verbose");
     cmd.assert()
         .success()
@@ -48,14 +65,44 @@ fn test_genaddr() -> Result<(), Box<dyn std::error::Error>> {
         .stdout(predicate::str::contains("wc:"))
         .stdout(predicate::str::contains("keys:"))
         .stdout(predicate::str::contains("Raw address"))
+        .stdout(predicate::str::contains("Seed phrase"))
         .stdout(predicate::str::contains("Succeded"));
+    Ok(())
+}
 
-        Ok(())
+#[test]
+fn test_genaddr_setkey() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
+    cmd.arg("genaddr")
+        .arg("tests/samples/wallet.tvc")
+        .arg("tests/samples/wallet.abi.json")
+        .arg("--setkey")
+        .arg("tests/samples/wallet.keys.json");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Raw address"))
+        .stdout(predicate::str::contains("Succeded"));
+    Ok(())
+}
+
+#[test]
+fn test_genaddr_wc() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
+    cmd.arg("genaddr")
+        .arg("tests/samples/wallet.tvc")
+        .arg("tests/samples/wallet.abi.json")
+        .arg("--wc")
+        .arg("-1");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Raw address: -1"))
+        .stdout(predicate::str::contains("Succeded"));
+    Ok(())
 }
 
 #[test]
 fn test_genaddr_initdata() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("tonlabs-cli")?;
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
     cmd.arg("genaddr")
         .arg("tests/data.tvc")
         .arg("tests/data.abi.json")


### PR DESCRIPTION
- `genaddr` improved. It generates seed phrase and prints it to terminal.
  From that phrase keypair is generated if `--genkey` option presents.
- Small refactoring: two crypto functions are moved to crypto crate.
- Small refactoring in generate_address.