### PR TITLE
Parse call arguments defined in the form of `--name value`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license-file = "LICENSE.md"
 keywords = ["TON", "SDK", "smart contract", "tonlabs"]
 edition = "2018"
-version = "0.1.2"
+version = "0.1.3"
 
 [dependencies]
 base64 = "0.10.1"
@@ -24,6 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_derive = "1.0.91"
 
+ton_abi = { git = "https://github.com/tonlabs/ton-labs-abi.git" }
 ton-client-rs = { git = 'https://github.com/tonlabs/ton-client-rs.git', default-features = false, branch = "0.23.0-rc" }
 ton_client = { git = 'https://github.com/tonlabs/TON-SDK.git',  default_features = false, features = ["node_interaction"] }
 ton_sdk = { git = 'https://github.com/tonlabs/TON-SDK.git', default-features = false }

--- a/README.md
+++ b/README.md
@@ -61,6 +61,27 @@ If `--abi` or `--sign` option is omitted in parameters it must present in config
 
     tonos-cli call [--abi <abi_file>] [--sign <keyfile>] <address> <method> <params>
 
+If `--abi` or `--sign` option is omitted in parameters, it must be specified in the config file. See below for more details.
+
+Alternative command:
+
+    tonos-cli callex <method> [<address>] [<abi>] [<keys>] params...
+
+`params...` - one or more function arguments in the form of  `--name value`.
+
+`address`, `abi`, and `keys` parameters can be omitted. In this case default values will be used from config file.
+
+Example:
+
+    tonos-cli callex submitTransaction 0:1b91c010f35b1f5b42a05ad98eb2df80c302c37df69651e1f5ac9c69b7e90d4e SafeMultisigWallet.abi.json msig.keys.json --dest 0:c63a050fe333fac24750e90e4c6056c477a2526f6217b5b519853c30495882c9 --value 1.5T --bounce false --allBalance false --payload ""
+
+Integer and address types can be supplied without quotes. 
+
+`--value 1.5T` - suffix `T` converts integer to nanotokens -> `1500000000`. The same as `--value 1500000000`.
+
+Arrays can be used without `[]` brackets.
+
+
 Run get-method:
 
     tonos-cli run [--abi <abi_file>] <address> <method> <params>

--- a/src/call.rs
+++ b/src/call.rs
@@ -13,6 +13,8 @@
  */
 use crate::config::Config;
 use crate::crypto::load_keypair;
+use crate::convert;
+use ton_abi::{Contract, ParamType};
 use chrono::{TimeZone, Local};
 use hex;
 use std::time::SystemTime;
@@ -267,4 +269,67 @@ pub fn call_contract_with_msg(conf: Config, str_msg: String, abi: String) -> Res
         println!("Result: {}", serde_json::to_string_pretty(&result.output).unwrap());
     }
     Ok(())
+}
+
+fn parse_integer_param(value: &str) -> Result<String, String> {
+    let value = value.trim_matches('\"');
+
+    if value.ends_with('T') {
+        convert::convert_token(value.trim_end_matches('T'))
+    } else {
+        Ok(value.to_owned())
+    }
+}
+
+fn build_json_from_params(params_vec: Vec<&str>, abi: &str, method: &str) -> Result<String, String> {
+    let abi_obj = Contract::load(abi.as_bytes()).map_err(|e| format!("failed to parse ABI: {}", e))?;
+    let functions = abi_obj.functions();
+        
+    let func_obj = functions.get(method).unwrap();
+    let inputs = func_obj.input_params();
+
+    let mut params_json = json!({ });
+    for input in inputs {
+        let mut iter = params_vec.iter();
+        let _param = iter.find(|x| x.trim_start_matches('-') == input.name)
+            .ok_or(format!(r#"argument "{}" of type "{}" not found"#, input.name, input.kind))?;
+
+        let value = iter.next()
+            .ok_or(format!(r#"argument "{}" of type "{}" has no value"#, input.name, input.kind))?
+            .to_string();
+
+        let value = match input.kind {
+            ParamType::Uint(_) | ParamType::Int(_) => {
+                json!(parse_integer_param(&value)?)
+            },
+            ParamType::Array(ref x) => {
+                if let ParamType::Uint(_) = **x {
+                    let mut result_vec: Vec<String> = vec![];
+                    for i in value.split(|c| c == ',' || c == '[' || c == ']') {
+                        if i != "" {
+                            result_vec.push(parse_integer_param(i)?)
+                        }
+                    }
+                    json!(result_vec)
+                } else {
+                    json!(value)
+                }
+            },
+            _ => {
+                json!(value)
+            }
+        };
+        params_json[input.name.clone()] = value;
+    }
+
+    serde_json::to_string(&params_json).map_err(|e| format!("{}", e))
+}
+
+pub fn parse_params(params_vec: Vec<&str>, abi: &str, method: &str) -> Result<String, String> {
+    if params_vec.len() == 1 {
+        // if there is only 1 parameter it must be a json string with arguments
+        Ok(params_vec[0].to_owned())
+    } else {
+        build_json_from_params(params_vec, abi, method)
+    }
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,22 @@
+
+pub fn convert_token(amount: &str) -> Result<String, String> {
+    let parts: Vec<&str> = amount.split(".").collect();
+    if parts.len() >= 1 && parts.len() <= 2 {
+        let mut result = String::new();
+        result += parts[0];
+        if parts.len() == 2 {
+            let fraction = format!("{:0<9}", parts[1]);
+            if fraction.len() != 9 {
+                return Err("invalid fractional part".to_string());
+            }
+            result += &fraction;
+        } else {
+            result += "000000000";
+        }
+        u64::from_str_radix(&result, 10)
+            .map_err(|e| format!("failed to parse amount: {}", e))?;
+        
+        return Ok(result);
+    }
+    Err("Invalid amout value".to_string())
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -189,3 +189,63 @@ fn test_deploy() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn test_callex() -> Result<(), Box<dyn std::error::Error>> {
+    let giver_abi_name = "tests/samples/giver.abi.json";
+    
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
+    cmd.arg("callex")
+        .arg("sendGrams")
+        .arg("0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94")
+        .arg(giver_abi_name)
+        .arg("--")
+        .arg("--dest")
+        .arg("0:1b91c010f35b1f5b42a05ad98eb2df80c302c37df69651e1f5ac9c69b7e90d4e")
+        .arg("--amount")
+        .arg("0.2T");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(r#""dest":"0:1b91c010f35b1f5b42a05ad98eb2df80c302c37df69651e1f5ac9c69b7e90d4e""#))
+        .stdout(predicate::str::contains(r#""amount":"0200000000""#))
+        .stdout(predicate::str::contains("Succeeded"));
+
+
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
+        cmd.arg("callex")
+            .arg("sendGrams")
+            .arg("0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94")
+            .arg(giver_abi_name)
+            .arg("--")
+            .arg("--dest")
+            .arg("0:1b91c010f35b1f5b42a05ad98eb2df80c302c37df69651e1f5ac9c69b7e90d4e")
+            .arg("--amount")
+            .arg("1000000000");
+        cmd.assert()
+            .success();
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(r#""dest":"0:1b91c010f35b1f5b42a05ad98eb2df80c302c37df69651e1f5ac9c69b7e90d4e""#))
+        .stdout(predicate::str::contains(r#""amount":"1000000000""#))
+        .stdout(predicate::str::contains("Succeeded"));
+
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
+        cmd.arg("callex")            
+            .arg("sendGrams")
+            .arg("0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94")
+            .arg(giver_abi_name)
+            .arg("--")
+            .arg("--dest")
+            .arg("0:1b91c010f35b1f5b42a05ad98eb2df80c302c37df69651e1f5ac9c69b7e90d4e")
+            .arg("--amount")
+            .arg("0x10000");
+        cmd.assert()
+            .success();
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(r#""dest":"0:1b91c010f35b1f5b42a05ad98eb2df80c302c37df69651e1f5ac9c69b7e90d4e""#))
+        .stdout(predicate::str::contains(r#""amount":"0x10000""#))
+        .stdout(predicate::str::contains("Succeeded"));
+
+    Ok(())
+}


### PR DESCRIPTION
Add callex cmd with user-friendly params.
- Function parameters must be defined in the form: --name value. Without
  quotes.
- Integer parameter can be suffixed with `T`. Such parameter is
  automatically converted to nanovalue.
- Array of integers can be defined without brackets `[]`.
- [ADDRESS] [ABI] and [SIGN] positional parameters of `callex` commands
  can be omitted and in that case default values will be used from
  config file.

Example:
```
tonos-cli callex submitTransaction 0:3b1e9d91d11e4908c9a0455ce8abae9035359d619f8c52da7f8eb7843b50ada4 SafeMultisigWallet.abi.json msig.keys.json --dest 0:3b1e9d91d11e4908c9a0455ce8abae9035359d619f8c52da7f8eb7843b50ada4 --value 1T --bounce false --allBalance false --payload ""
```