### PR TITLE
Small fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "Apache-2.0"
 keywords = ["TON", "SDK", "smart contract", "tonlabs"]
 edition = "2018"
-version = "0.1.8"
+version = "0.1.9"
 
 [dependencies]
 base64 = "0.10.1"

--- a/README.md
+++ b/README.md
@@ -122,13 +122,22 @@ Run funC get-method:
 
 ### 6) Store Parameter Values in the Configuration File
 
-tonos-cli can remember some parameter values and use it automatically in `deploy`, `call` and `run` subcommands.
+tonos-cli can remember some parameter values and use it automatically in all subcommands.
 
     tonos-cli config [--url <url>] [--abi <abifile>] [--keys <keysfile>]
 
-Example: `tonos-cli config --abi wallet.abi.json --keys wallet_keys.json`
+Example: `tonos-cli config --url https://main.ton.dev --abi wallet.abi.json --keys wallet_keys.json`
 
-After that you can omit `--abi` and `--sign` parameters in `deploy`, `call` and `run` subcommands. 
+After that you can omit `--abi` and `--sign` parameters in `deploy`, `call` and `run` subcommands and cli by default will connect to main.ton.dev network.
+
+`config` command creates config file in current working directory which will be used by cli at every start. To override searching config file in current dir use the following methods:
+
+ - define environment variable `TONOSCLI_CONFIG` with path to your config file;
+ - define global option `--config <path_to_file>` before any other subcommand (example: `tonos-cli --config ../config.json call ...`).
+
+ Global option has higher priority than env variable.
+
+ Also you can explicitly define network in every subcommand by using global option `--url <network>` (example: `tonos-cli --url https://main.ton.dev account <address>`).
 
 ### 7) Get Account Info
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -10,9 +10,10 @@
 * See the License for the specific TON DEV software governing permissions and
 * limitations under the License.
 */
+use crate::call::create_client_verbose;
 use crate::config::Config;
 use serde_json::json;
-use ton_client_rs::{TonClient, TonAddress};
+use ton_client_rs::TonAddress;
 
 const ACCOUNT_FIELDS: &str = r#"
     acc_type_name
@@ -23,8 +24,7 @@ const ACCOUNT_FIELDS: &str = r#"
 "#;
 
 pub fn get_account(conf: Config, addr: &str) -> Result<(), String> {
-    let ton = TonClient::new_with_base_url(&conf.url)
-        .map_err(|e| format!("failed to create tonclient: {}", e.to_string()))?;
+    let ton = create_client_verbose(&conf)?;
 
     TonAddress::from_str(addr)
         .map_err(|e| format!("failed to parse address: {}", e.to_string()))?;

--- a/src/call.rs
+++ b/src/call.rs
@@ -40,6 +40,11 @@ fn create_client(conf: &Config) -> Result<TonClient, String> {
     .map_err(|e| format!("failed to create tonclient: {}", e.to_string()))
 }
 
+pub fn create_client_verbose(conf: &Config) -> Result<TonClient, String> {
+    println!("Connecting to {}", conf.url);
+    create_client(conf)
+}
+
 fn prepare_message(
     ton: &TonClient,
     addr: &TonAddress,
@@ -200,7 +205,7 @@ pub fn call_contract_with_result(
     keys: Option<String>,
     local: bool,
 ) -> Result<serde_json::Value, String> {
-    let ton = create_client(&conf)?;
+    let ton = create_client_verbose(&conf)?;
 
     let ton_addr = TonAddress::from_str(addr)
         .map_err(|e| format!("failed to parse address: {}", e.to_string()))?;
@@ -301,7 +306,7 @@ pub fn generate_message(
 }
 
 pub fn call_contract_with_msg(conf: Config, str_msg: String, abi: String) -> Result<(), String> {
-    let ton = create_client(&conf)?;
+    let ton = create_client_verbose(&conf)?;
 
     let (msg, method) = unpack_message(&str_msg)?;
     print_encoded_message(&msg);
@@ -336,7 +341,7 @@ pub fn parse_params(params_vec: Vec<&str>, abi: &str, method: &str) -> Result<St
 }
 
 pub fn run_get_method(conf: Config, addr: &str, method: &str, params: Option<String>) -> Result<(), String> {
-    let ton = create_client(&conf)?;
+    let ton = create_client_verbose(&conf)?;
 
     let ton_addr = TonAddress::from_str(addr)
         .map_err(|e| format!("failed to parse address: {}", e.to_string()))?;

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -10,13 +10,12 @@
  * See the License for the specific TON DEV software governing permissions and
  * limitations under the License.
  */
+use crate::call::create_client_verbose;
 use crate::config::Config;
 use crate::crypto::load_keypair;
-use ton_client_rs::TonClient;
 
 pub fn deploy_contract(conf: Config, tvc: &str, abi: &str, params: &str, keys_file: &str, wc: i32) -> Result<(), String> {
-    let ton = TonClient::new_with_base_url(&conf.url)
-        .map_err(|e| format!("failed to create tonclient: {}", e.to_string()))?;
+    let ton = create_client_verbose(&conf)?;
     
     let abi = std::fs::read_to_string(abi)
         .map_err(|e| format!("failed to read ABI file: {}", e.to_string()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARR{ANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific TON DEV software governing permissions and
  * limitations under the License.
  */


### PR DESCRIPTION
Several fixes

- Fixed key block query
- Fixed bug with case when there is no key block
- Printed network name to which cli is connecting
- Network url can be defined explicitly in any subcmd
- Path to config file can be defined by env var or by cmd line option
- Added tests for overriding path to config file
- Updated readme
- Increased version
