### PR TITLE
Implement `depool events` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "Apache-2.0"
 keywords = ["TON", "SDK", "smart contract", "tonlabs"]
 edition = "2018"
-version = "0.1.14"
+version = "0.1.15"
 
 [dependencies]
 base64 = "0.10.1"

--- a/README.md
+++ b/README.md
@@ -239,3 +239,13 @@ all `--value` parameters must be defined in tons, like this: `--value 10.5`, it 
 ### Enable/disable autoresuming
 
     tonos-cli depool [--addr <depool_address>] autoresume on | off [--wallet <msig_address>] [--sign <key_file or seed_phrase>]
+
+### View depool events
+
+    tonos-cli depool [--addr <depool_address>] events [--since <utime>]
+
+Prints depool events since defined unixtime. if `--since` is omitted then prints all depool events.
+
+    tonos-cli depool [--addr <depool_address>] events --wait-one
+
+Waits until new event will be emitted and then prints it to the stdout.

--- a/src/call.rs
+++ b/src/call.rs
@@ -13,10 +13,10 @@
 use crate::config::Config;
 use crate::crypto::load_keypair;
 use crate::convert;
+use crate::helpers::now;
 use ton_abi::{Contract, ParamType};
 use chrono::{TimeZone, Local};
 use hex;
-use std::time::SystemTime;
 use ton_client_rs::{
     TonClient, TonClientConfig, TonAddress, EncodedMessage
 };
@@ -45,10 +45,6 @@ impl log::Log for SimpleLogger {
     fn flush(&self) {}
 }
 
-fn now() -> u32 {
-    SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as u32
-}
-
 fn create_client(conf: &Config) -> Result<TonClient, String> {
     TonClient::new(&TonClientConfig{
         base_url: Some(conf.url.clone()),
@@ -56,7 +52,7 @@ fn create_client(conf: &Config) -> Result<TonClient, String> {
         message_expiration_timeout: Some(conf.timeout),
         message_expiration_timeout_grow_factor: Some(1.5),
         message_processing_timeout: Some(conf.timeout),
-        wait_for_timeout: None,
+        wait_for_timeout: Some(60 * 60000),
         access_key: None,
         out_of_sync_threshold: None,
     })

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -11,6 +11,7 @@
  * limitations under the License.
  */
 use ton_client_rs::{Ed25519KeyPair, TonAddress};
+use std::time::SystemTime;
 
 pub fn read_keys(filename: &str) -> Result<Ed25519KeyPair, String> {
     let keys_str = std::fs::read_to_string(filename)
@@ -22,4 +23,8 @@ pub fn read_keys(filename: &str) -> Result<Ed25519KeyPair, String> {
 pub fn load_ton_address(addr: &str) -> Result<TonAddress, String> {
     TonAddress::from_str(addr)
         .map_err(|e| format!("failed to parse address: {}", e.to_string()))
+}
+
+pub fn now() -> u32 {
+    SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs() as u32
 }


### PR DESCRIPTION
Added new command `depool events [--since <utime>]` : prints all events since 0 or defined utime.
Extended command `depool events --wait-one` : waits for a new event from depool and prints it.