### PR TITLE
Add debot support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "Apache-2.0"
 keywords = ["TON", "SDK", "smart contract", "tonlabs"]
 edition = "2018"
-version = "0.1.19"
+version = "0.1.20"
 
 [dependencies]
 base64 = "0.10.1"
@@ -25,6 +25,7 @@ serde_json = "1.0"
 serde_derive = "1.0.91"
 sha2 = "0.8"
 log = "0.4.11"
+simplelog = "0.8.0"
 
 ton_abi = { git = "https://github.com/tonlabs/ton-labs-abi.git" }
 ton-client-rs = { git = 'https://github.com/tonlabs/ton-client-rs.git', tag = "0.26.0" }
@@ -32,6 +33,8 @@ ton_client = { git = 'https://github.com/tonlabs/TON-SDK.git', tag = "0" }
 ton_sdk = { git = 'https://github.com/tonlabs/TON-SDK.git', tag = "0" }
 ton_types = { git = "https://github.com/tonlabs/ton-labs-types.git" }
 ton_block = { git = "https://github.com/tonlabs/ton-labs-block.git" }
+
+debot-engine = { git = 'https://github.com/tonlabs/debot-engine.git', tag = "v0.1.0" }
 
 [dev-dependencies]
 assert_cmd = "0.11"

--- a/src/debot/mod.rs
+++ b/src/debot/mod.rs
@@ -1,0 +1,90 @@
+/*
+* Copyright 2018-2020 TON DEV SOLUTIONS LTD.
+*
+* Licensed under the SOFTWARE EVALUATION License (the "License"); you may not use
+* this file except in compliance with the License.
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific TON DEV software governing permissions and
+* limitations under the License.
+*/
+use crate::config::Config;
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+use simplelog::*;
+use term_browser::run_debot_browser;
+
+pub mod term_browser;
+
+pub fn create_debot_command<'a, 'b>() -> App<'a, 'b> {
+    SubCommand::with_name("debot")
+        .about("Debot commands.")
+        .setting(AppSettings::AllowLeadingHyphen)
+        .setting(AppSettings::TrailingVarArg)
+        .setting(AppSettings::DontCollapseArgsInUsage)
+        .arg(Arg::with_name("DEBUG").long("--debug").short("-d"))
+        .subcommand(
+            SubCommand::with_name("fetch")
+                .arg(
+                    Arg::with_name("ADDRESS")
+                        .required(true)
+                        .help("Debot address."),
+                )
+                .arg(
+                    Arg::with_name("ABI")
+                        .long("--abi")
+                        .takes_value(true)
+                        .help("Debot ABI."),
+                ),
+        )
+}
+
+pub fn debot_command(m: &ArgMatches, config: Config) -> Result<(), String> {
+    let debug = m.is_present("DEBUG");
+    let log_conf = ConfigBuilder::new()
+        .add_filter_ignore_str("executor")
+        .add_filter_ignore_str("hyper")
+        .add_filter_ignore_str("reqwest")
+        .build();
+
+    let mut loggers: Vec<Box<dyn SharedLogger>> = vec![];
+    let file = std::fs::File::create("debot_err.log");
+    if file.is_ok() {
+        loggers.push(WriteLogger::new(
+            LevelFilter::Error,
+            log_conf.clone(),
+            file.unwrap(),
+        ));
+    }
+
+    if debug {
+        loggers.push(TermLogger::new(
+            LevelFilter::Debug,
+            log_conf.clone(),
+            TerminalMode::Mixed,
+        ));
+    }
+    CombinedLogger::init(loggers).unwrap();
+
+    if let Some(m) = m.subcommand_matches("fetch") {
+        return fetch_command(m, config);
+    }
+    Err("unknown debot command".to_owned())
+}
+
+fn fetch_command(m: &ArgMatches, config: Config) -> Result<(), String> {
+    let addr = m.value_of("ADDRESS");
+    let abi = m
+        .value_of("ABI")
+        .map(|s| s.to_string())
+        .or(config.abi_path.clone());
+
+    let abi = abi
+        .map(|s| {
+            std::fs::read_to_string(s)
+                .map_err(|e| format!("failed to read ABI file: {}", e.to_string()))
+        })
+        .transpose()?;
+    return run_debot_browser(addr.unwrap(), abi, config);
+}

--- a/src/debot/term_browser.rs
+++ b/src/debot/term_browser.rs
@@ -1,0 +1,191 @@
+/*
+* Copyright 2018-2020 TON DEV SOLUTIONS LTD.
+*
+* Licensed under the SOFTWARE EVALUATION License (the "License"); you may not use
+* this file except in compliance with the License.
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific TON DEV software governing permissions and
+* limitations under the License.
+*/
+use crate::config::Config;
+use crate::crypto::{generate_keypair_from_mnemonic, keypair_to_ed25519pair};
+use crate::helpers::load_ton_address;
+use debot_engine::{BrowserCallbacks, DAction, DEngine, STATE_EXIT};
+use std::cell::RefCell;
+use std::io::{self, Write};
+use std::rc::Rc;
+use ton_client_rs::{Ed25519KeyPair, TonAddress};
+
+struct TerminalBrowser {
+    state_id: u8,
+    active_actions: Vec<DAction>,
+    network: String,
+}
+
+impl TerminalBrowser {
+    pub fn new(network: String) -> Self {
+        Self {
+            state_id: 0,
+            active_actions: vec![],
+            network,
+        }
+    }
+
+    pub fn select_action(&self) -> Option<DAction> {
+        if self.state_id == STATE_EXIT {
+            return None;
+        }
+        if self.active_actions.len() == 0 {
+            debug!("no more actions, exit loop");
+            return None;
+        }
+
+        loop {
+            let res = action_input(self.active_actions.len());
+            if res.is_err() {
+                println!("{}", res.unwrap_err());
+                continue;
+            }
+            let (n, _, _) = res.unwrap();
+            let act = self.active_actions.get(n - 1);
+            if act.is_none() {
+                println!("Invalid action. Try again.");
+                continue;
+            }
+            return act.map(|a| a.clone());
+        }
+    }
+}
+
+struct Callbacks {
+    browser: Rc<RefCell<TerminalBrowser>>,
+}
+
+impl Callbacks {
+    pub fn new(browser: Rc<RefCell<TerminalBrowser>>) -> Self {
+        Self { browser }
+    }
+}
+
+impl BrowserCallbacks for Callbacks {
+    /// Debot asks browser to print message to user
+    fn log(&self, msg: String) {
+        println!("{}", msg);
+    }
+
+    /// Debot is switched to another context.
+    fn switch(&self, ctx_id: u8) {
+        debug!("switched to ctx {}", ctx_id);
+        self.browser.borrow_mut().state_id = ctx_id;
+        if ctx_id == STATE_EXIT {
+            println!("Debot shutdown");
+            return;
+        }
+
+        self.browser.borrow_mut().active_actions = vec![];
+    }
+
+    /// Debot asks browser to show user an action from the context
+    fn show_action(&self, act: DAction) {
+        let mut browser = self.browser.borrow_mut();
+        println!("{}) {}", browser.active_actions.len() + 1, act.desc);
+        browser.active_actions.push(act);
+    }
+
+    // Debot engine asks user to enter argument for an action.
+    fn input(&self, prefix: &str, value: &mut String) {
+        let mut input_str = "".to_owned();
+        let mut argc = 0;
+        while argc == 0 {
+            print!("{} > ", prefix);
+            let _ = io::stdout().flush();
+            if let Err(e) = io::stdin().read_line(&mut input_str) {
+                println!("failed to read line: {}", e)
+            }
+            argc = input_str
+                .split_whitespace()
+                .map(|x| x.parse::<String>().unwrap())
+                .collect::<Vec<String>>()
+                .len();
+        }
+        *value = input_str.trim().to_owned();
+    }
+
+    /// Debot engine requests keys to sign something
+    fn load_key(&self, keys: &mut Ed25519KeyPair) {
+        let mut value = String::new();
+        self.input("enter seed phrase", &mut value);
+
+        let mut pair = generate_keypair_from_mnemonic(&value);
+        while let Err(_) = pair {
+            println!("Invalid seed phrase. Try again");
+            self.input("enter seed phrase", &mut value);
+            pair = generate_keypair_from_mnemonic(&value);
+        }
+        *keys = keypair_to_ed25519pair(pair.unwrap()).unwrap();
+    }
+    /// Debot asks to run action of another debot
+    fn invoke_debot(&self, debot: TonAddress, action: DAction) -> Result<(), String> {
+        debug!("fetching debot {} action {}", &debot, action.name);
+        println!("invoking debot {}", &debot);
+        let callbacks = Box::new(Callbacks::new(Rc::clone(&self.browser)));
+        let mut debot = DEngine::new(debot, None, &self.browser.borrow().network, callbacks);
+        debot.fetch()?;
+        debot.execute_action(&action)?;
+        loop {
+            let action = self.browser.borrow().select_action();
+            match action {
+                Some(act) => debot.execute_action(&act)?,
+                None => break,
+            }
+        }
+        Ok(())
+    }
+}
+
+fn action_input(max: usize) -> Result<(usize, usize, Vec<String>), String> {
+    let mut a_str = String::new();
+    let mut argc = 0;
+    let mut argv = vec![];
+    println!();
+    while argc == 0 {
+        print!("debash$ ");
+        let _ = io::stdout().flush();
+        io::stdin()
+            .read_line(&mut a_str)
+            .map_err(|e| format!("failed to read line: {}", e))?;
+        argv = a_str
+            .split_whitespace()
+            .map(|x| x.parse::<String>().expect("parse error"))
+            .collect::<Vec<String>>();
+        argc = argv.len();
+    }
+    let n = usize::from_str_radix(&argv[0], 10)
+        .map_err(|_| format!("Oops! Invalid action. Try again, please."))?;
+    if n > max {
+        Err(format!("Auch! Invalid action. Try again, please."))?;
+    }
+
+    Ok((n, argc, argv))
+}
+
+pub fn run_debot_browser(addr: &str, abi: Option<String>, config: Config) -> Result<(), String> {
+    let url = config.url.clone();
+    let browser = Rc::new(RefCell::new(TerminalBrowser::new(config.url)));
+
+    let callbacks = Box::new(Callbacks::new(Rc::clone(&browser)));
+    let mut debot = DEngine::new(load_ton_address(addr)?, abi, &url, callbacks);
+    debot.start()?;
+
+    loop {
+        let action = browser.borrow().select_action();
+        match action {
+            Some(act) => debot.execute_action(&act)?,
+            None => break,
+        }
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,12 +10,10 @@
  * See the License for the specific TON DEV software governing permissions and
  * limitations under the License.
  */
-#[macro_use]
-extern crate clap;
-#[macro_use]
-extern crate serde_json;
-#[macro_use]
-extern crate serde_derive;
+#[macro_use] extern crate clap;
+#[macro_use] extern crate log;
+#[macro_use] extern crate serde_json;
+#[macro_use] extern crate serde_derive;
 
 mod account;
 mod call;
@@ -23,6 +21,7 @@ mod config;
 mod convert;
 mod crypto;
 mod decode;
+mod debot;
 mod deploy;
 mod depool;
 mod depool_abi;
@@ -38,6 +37,7 @@ use call::{call_contract, call_contract_with_msg, generate_message, parse_params
 use clap::{ArgMatches, SubCommand, Arg, AppSettings};
 use config::{Config, set_config};
 use crypto::{generate_mnemonic, extract_pubkey, generate_keypair};
+use debot::{create_debot_command, debot_command};
 use decode::{create_decode_command, decode_command};
 use deploy::deploy_contract;
 use depool::{create_depool_command, depool_command};
@@ -284,6 +284,7 @@ fn main_internal() -> Result <(), String> {
         (subcommand: create_multisig_command())
         (subcommand: create_depool_command())
         (subcommand: create_decode_command())
+        (subcommand: create_debot_command())
         (@subcommand getconfig =>
             (about: "Reads global configuration parameter with defined index.")
             (@arg INDEX: +required +takes_value "Parameter index.")
@@ -394,6 +395,9 @@ fn main_internal() -> Result <(), String> {
     }
     if let Some(m) = matches.subcommand_matches("decode") {
         return decode_command(m, conf);
+    }
+    if let Some(m) = matches.subcommand_matches("debot") {
+        return debot_command(m, conf);
     }
     if let Some(_) = matches.subcommand_matches("version") {
         println!(


### PR DESCRIPTION
- Added `debot fetch` subcommand to run debot smart contracts.
- Added `debot --debug` flag to enable debot debug mode.
- Added simple console debot browser which uses debot-engine.