### PR TITLE
Update dengine tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ documentation = "https://docs.ton.dev"
 build = "build.rs"
 readme = "README.md"
 license = "Apache-2.0"
-keywords = ["TON", "SDK", "smart contract", "tonlabs"]
+keywords = ["TON", "SDK", "smart contract", "tonlabs", "solidity"]
 edition = "2018"
-version = "0.1.21"
+version = "0.1.22"
 
 [dependencies]
 base64 = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,8 @@ ton_sdk = { git = 'https://github.com/tonlabs/TON-SDK.git', tag = "0" }
 ton_types = { git = "https://github.com/tonlabs/ton-labs-types.git" }
 ton_block = { git = "https://github.com/tonlabs/ton-labs-block.git" }
 
-debot-engine = { git = 'https://github.com/tonlabs/debot-engine.git', tag = "v0.1.0" }
+debot-engine = { git = 'https://github.com/tonlabs/debot-engine.git', tag = "v0.1.1" }
 
 [dev-dependencies]
 assert_cmd = "0.11"
 predicates = "1"
-stdio-override = "0.1.3"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -40,8 +40,8 @@ impl log::Log for SimpleLogger {
 pub fn read_keys(filename: &str) -> Result<Ed25519KeyPair, String> {
     let keys_str = std::fs::read_to_string(filename)
         .map_err(|e| format!("failed to read keypair file: {}", e.to_string()))?;
-    let keys: Ed25519KeyPair = serde_json::from_str(&keys_str).unwrap();
-    Ok(keys)
+    serde_json::from_str(&keys_str)
+        .map_err(|e| format!("failed to parse keypair file: {}", e))
 }
 
 pub fn load_ton_address(addr: &str) -> Result<TonAddress, String> {


### PR DESCRIPTION
- `load keys` test refactored: removed stdio-override crate, functions `input` and `input_keys` are made generic.
- Handled error when keypair file was invalid json.