### PR TITLE
Fix browser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "Apache-2.0"
 keywords = ["TON", "SDK", "smart contract", "tonlabs", "solidity"]
 edition = "2018"
-version = "0.1.27"
+version = "0.1.28"
 
 [dependencies]
 base64 = "0.10.1"


### PR DESCRIPTION
Bug fix with invoking another debot.
When invoked debot exits it terminates debot browser and as a result control flow doesn't return to main debot context.
Fixed: new debot browser created in `invoke_debot` callback.