### PR TITLE
Fixed success on fail to decode the result

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -335,7 +335,11 @@ async fn send_message_and_wait(
             },
         ).await
         .map_err(|e| format!("run failed: {:#}", e))?;
-        Ok(result.decoded.and_then(|d| d.output).unwrap_or(json!({})))
+        let res = result.decoded.and_then(|d| d.output)
+            .ok_or("Failed to decode the result. Check that abi matches the contract.")?;
+        Ok(res)
+
+
     } else {
         if !conf.is_json {
             println!("Processing... ");
@@ -376,6 +380,7 @@ async fn send_message_and_wait(
             error_handler(err.clone());
             return Err(format!("{:#}", err));
         }
+        println!("{:?}", result);
         Ok(result.unwrap().decoded.and_then(|d| d.output).unwrap_or(json!({})))
     }
 }
@@ -461,7 +466,7 @@ pub async fn call_contract_with_result(
         let err = result.err().unwrap();
         println!("{}", err);
 
-        if !retry {
+        if !retry || local {
             break;
         }
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -380,7 +380,6 @@ async fn send_message_and_wait(
             error_handler(err.clone());
             return Err(format!("{:#}", err));
         }
-        println!("{:?}", result);
         Ok(result.unwrap().decoded.and_then(|d| d.output).unwrap_or(json!({})))
     }
 }


### PR DESCRIPTION
#patch
Fixed wrong behaviour when tonos-cli returns success on run call, when it can't decode the result